### PR TITLE
feat(SCRUM-157-162): add group search to global search bar

### DIFF
--- a/backend/src/main/java/com/my_app/schoolboard/controller/GroupController.java
+++ b/backend/src/main/java/com/my_app/schoolboard/controller/GroupController.java
@@ -85,4 +85,12 @@ public class GroupController {
             Authentication authentication) {
         return ResponseEntity.ok(groupService.getGroupMembers(id, authentication.getName()));
     }
+
+    @GetMapping("/search")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<List<GroupResponseDTO>> searchGroups(
+            @jakarta.validation.constraints.NotBlank @org.springframework.web.bind.annotation.RequestParam("keyword") String keyword,
+            Authentication authentication) {
+        return ResponseEntity.ok(groupService.searchGroups(keyword, authentication.getName()));
+    }
 }

--- a/backend/src/main/java/com/my_app/schoolboard/repository/GroupRepository.java
+++ b/backend/src/main/java/com/my_app/schoolboard/repository/GroupRepository.java
@@ -23,4 +23,18 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
             ORDER BY g.createdAt DESC
             """)
     List<Group> findAccessibleGroups(@Param("userId") Long userId);
+
+    @Query("""
+            SELECT DISTINCT g
+            FROM StudyGroup g
+            LEFT JOIN GroupMember gm
+                ON gm.group = g
+               AND gm.user.id = :userId
+            WHERE (LOWER(g.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
+               OR LOWER(g.description) LIKE LOWER(CONCAT('%', :keyword, '%')))
+              AND (g.visibility = com.my_app.schoolboard.model.GroupVisibility.PUBLIC
+               OR gm.id IS NOT NULL)
+            ORDER BY g.createdAt DESC
+            """)
+    List<Group> searchGroups(@Param("keyword") String keyword, @Param("userId") Long userId);
 }

--- a/backend/src/main/java/com/my_app/schoolboard/service/GroupService.java
+++ b/backend/src/main/java/com/my_app/schoolboard/service/GroupService.java
@@ -20,4 +20,5 @@ public interface GroupService {
     void leaveGroup(Long groupId, String username);
 
     List<GroupMemberDTO> getGroupMembers(Long groupId, String username);
+    List<GroupResponseDTO> searchGroups(String keyword, String username);
 }

--- a/backend/src/main/java/com/my_app/schoolboard/service/impl/GroupServiceImpl.java
+++ b/backend/src/main/java/com/my_app/schoolboard/service/impl/GroupServiceImpl.java
@@ -150,6 +150,19 @@ public class GroupServiceImpl implements GroupService {
                 .toList();
     }
 
+    @Override
+    public List<GroupResponseDTO> searchGroups(String keyword, String username) {
+        User currentUser = getUserByUsername(username);
+        return groupRepository.searchGroups(keyword.trim(), currentUser.getId()).stream()
+                .map(group -> {
+                    GroupMember membership = getMembership(group.getId(), currentUser.getId()).orElse(null);
+                    return mapToGroupResponse(group, currentUser.getId(),
+                            membership != null ? membership.getRole() : null,
+                            membership != null);
+                })
+                .toList();
+    }
+
     private Group getGroupOrThrow(Long groupId) {
         return groupRepository.findById(groupId)
                 .orElseThrow(() -> new ResourceNotFoundException("Group", "id", groupId));

--- a/frontend/src/components/navbar/UserSearchDropdown.jsx
+++ b/frontend/src/components/navbar/UserSearchDropdown.jsx
@@ -3,7 +3,9 @@ import { Search, Loader2, FileText, X } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { searchUsers } from '../../services/userSearchService';
 import { postService } from '../../services/postService';
+import groupService from '../../services/groupService';
 import UserCard from '../UserCard';
+import { Users, Globe2, Lock } from 'lucide-react';
 
 const UserSearchDropdown = () => {
   const navigate = useNavigate();
@@ -11,6 +13,7 @@ const UserSearchDropdown = () => {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState([]);
   const [postResults, setPostResults] = useState([]);
+  const [groupResults, setGroupResults] = useState([]);
   const [isOpen, setIsOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
@@ -43,6 +46,7 @@ const UserSearchDropdown = () => {
     if (sanitizedQuery.length < 1) {
       setResults([]);
       setPostResults([]);
+      setGroupResults([]);
       setError('');
       return;
     }
@@ -52,15 +56,18 @@ const UserSearchDropdown = () => {
       setIsLoading(true);
       setError('');
       try {
-        const [userResponse, postResponse] = await Promise.allSettled([
+        const [userResponse, postResponse, groupResponse] = await Promise.allSettled([
           searchUsers(sanitizedQuery, 0, 10),
           postService.searchPosts(sanitizedQuery),
+          groupService.searchGroups(sanitizedQuery),
         ]);
         setResults(userResponse.status === 'fulfilled' ? (userResponse.value.data?.content || []) : []);
         setPostResults(postResponse.status === 'fulfilled' ? (postResponse.value || []) : []);
+        setGroupResults(groupResponse.status === 'fulfilled' ? (groupResponse.value || []) : []);
       } catch (searchError) {
         setResults([]);
         setPostResults([]);
+        setGroupResults([]);
         setError('Search failed. Try again.');
       } finally {
         setIsLoading(false);
@@ -74,6 +81,7 @@ const UserSearchDropdown = () => {
     setQuery('');
     setResults([]);
     setPostResults([]);
+    setGroupResults([]);
     setIsOpen(false);
   };
 
@@ -88,6 +96,12 @@ const UserSearchDropdown = () => {
     setQuery('');
     // Navigate to the specific post using a descriptive URL
     navigate(`/posts/${post.id}`);
+  };
+
+  const handleGroupClick = (groupId) => {
+    setIsOpen(false);
+    setQuery('');
+    navigate(`/groups/${groupId}`);
   };
 
   const formatDate = (dateString) => {
@@ -112,7 +126,7 @@ const UserSearchDropdown = () => {
           value={query}
           onChange={(event) => setQuery(event.target.value)}
           onFocus={() => setIsOpen(true)}
-          placeholder="Search users or posts..."
+          placeholder="Search users, posts or groups..."
           className="block w-full pl-10 pr-10 py-2.5 border border-gray-200 rounded-xl leading-5 bg-gray-50 placeholder-gray-400 focus:outline-none focus:bg-white focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 sm:text-sm transition"
         />
         {query && (
@@ -131,7 +145,7 @@ const UserSearchDropdown = () => {
           {!query.trim() ? (
             <div className="py-8 text-center">
               <Search className="w-8 h-8 text-gray-200 mx-auto mb-2" />
-              <p className="text-sm text-gray-500 font-medium">Search for users or posts</p>
+              <p className="text-sm text-gray-500 font-medium">Search for users, posts or groups</p>
               <p className="text-xs text-gray-400">Try searching "math" or a name</p>
             </div>
           ) : isLoading ? (
@@ -140,7 +154,7 @@ const UserSearchDropdown = () => {
             </div>
           ) : error ? (
             <p className="text-sm text-red-600 py-3">{error}</p>
-          ) : results.length === 0 && postResults.length === 0 ? (
+          ) : results.length === 0 && postResults.length === 0 && groupResults.length === 0 ? (
             <p className="text-sm text-gray-500 py-3">No results found for &apos;{query.trim()}&apos;</p>
           ) : (
             <>
@@ -190,6 +204,56 @@ const UserSearchDropdown = () => {
                                 <span className="text-xs text-gray-400">{formatDate(post.createdAt)}</span>
                               </>
                             )}
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Groups Section */}
+              {groupResults.length > 0 && (
+                <div>
+                  {(results.length > 0 || postResults.length > 0) && <hr className="my-2 border-gray-100" />}
+                  <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider px-2 py-1.5">Groups</p>
+                  <div className="space-y-1">
+                    {groupResults.map((group) => (
+                      <div
+                        key={group.id}
+                        onClick={() => handleGroupClick(group.id)}
+                        className="flex items-start gap-3 p-2.5 rounded-lg hover:bg-gray-50 cursor-pointer transition"
+                      >
+                        <div className="w-8 h-8 rounded-lg bg-blue-50 flex items-center justify-center flex-shrink-0 mt-0.5">
+                          {group.imageUrl ? (
+                            <img src={group.imageUrl} alt="" className="w-full h-full rounded-lg object-cover" />
+                          ) : (
+                            <Users className="w-4 h-4 text-blue-500" />
+                          )}
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-semibold text-gray-800 leading-snug truncate">
+                            {group.name}
+                          </p>
+                          <div className="flex items-center gap-2 mt-0.5">
+                            <span className="text-xs text-gray-400 font-medium truncate">
+                              {group.subject} • {group.academicLevel}
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-2 mt-0.5">
+                            <span className="flex items-center gap-1 text-[10px] text-gray-400">
+                              <Users className="w-3 h-3" />
+                              {group.memberCount || 0}
+                            </span>
+                            <span className="text-gray-300">·</span>
+                            <span className="flex items-center gap-1 text-[10px] text-gray-400">
+                              {group.visibility === 'PRIVATE' ? (
+                                <Lock className="w-3 h-3 text-amber-500" />
+                              ) : (
+                                <Globe2 className="w-3 h-3 text-emerald-500" />
+                              )}
+                              {group.visibility === 'PRIVATE' ? 'Private' : 'Public'}
+                            </span>
                           </div>
                         </div>
                       </div>

--- a/frontend/src/services/groupService.js
+++ b/frontend/src/services/groupService.js
@@ -70,6 +70,15 @@ const groupService = {
       throw error.response?.data || new Error('Network error fetching group members');
     }
   },
+  searchGroups: async (keyword) => {
+    try {
+      const response = await apiClient.get(`/groups/search?keyword=${encodeURIComponent(keyword)}`);
+      return response.data;
+    } catch (error) {
+      console.error('Error searching groups:', error);
+      throw error.response?.data || new Error('Network error searching groups');
+    }
+  },
 };
 
 export default groupService;


### PR DESCRIPTION
📝 Description

This PR adds group search functionality to the existing global search bar.

Users can now search for groups directly from the search bar alongside users and posts.

✨ Changes
Backend
Added group search query (name + description, case-insensitive)
Implemented searchGroups service method
Added /groups/search endpoint
Enforced visibility rules:
public groups
or groups the user is a member of
Frontend
Integrated group search into existing search flow
Added Groups section in search dropdown
Implemented navigation to /groups/:groupId
Updated search placeholder text
Handled empty results and edge cases
✅ Acceptance Criteria
 Search bar is visible and functional
 Users can search groups by name or description
 Matching groups are displayed in results
 "No groups found" handled gracefully
 Results load without errors
 Clicking a group navigates correctly
 Existing user and post search remain unaffected
🧪 Testing

Manually tested:

 Search by group name
 Search by description keyword
 Navigation to group page works
 Private groups not visible unless joined
 No UI or console errors
 User and post search still working
📌 Notes
No UI redesign
Reused existing search architecture
Maintained debounce behavior