### PR TITLE
feat(SCRUM-169-174): add category-based group filtering

### DIFF
--- a/backend/src/main/java/com/my_app/schoolboard/controller/GroupController.java
+++ b/backend/src/main/java/com/my_app/schoolboard/controller/GroupController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.my_app.schoolboard.dto.CreateGroupRequestDTO;
@@ -54,7 +55,12 @@ public class GroupController {
 
     @GetMapping
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<List<GroupResponseDTO>> getGroups(Authentication authentication) {
+    public ResponseEntity<List<GroupResponseDTO>> getGroups(
+            @RequestParam(value = "category", required = false) String category,
+            Authentication authentication) {
+        if (category != null && !category.trim().isEmpty()) {
+            return ResponseEntity.ok(groupService.filterGroupsByCategory(category, authentication.getName()));
+        }
         return ResponseEntity.ok(groupService.getGroups(authentication.getName()));
     }
 

--- a/backend/src/main/java/com/my_app/schoolboard/repository/GroupRepository.java
+++ b/backend/src/main/java/com/my_app/schoolboard/repository/GroupRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.my_app.schoolboard.model.Group;
+import com.my_app.schoolboard.model.GroupType;
 
 @Repository
 public interface GroupRepository extends JpaRepository<Group, Long> {
@@ -23,6 +24,19 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
             ORDER BY g.createdAt DESC
             """)
     List<Group> findAccessibleGroups(@Param("userId") Long userId);
+
+       @Query("""
+          SELECT DISTINCT g
+          FROM StudyGroup g
+          LEFT JOIN GroupMember gm
+         ON gm.group = g
+             AND gm.user.id = :userId
+          WHERE g.groupType = :groupType
+            AND (g.visibility = com.my_app.schoolboard.model.GroupVisibility.PUBLIC
+             OR gm.id IS NOT NULL)
+          ORDER BY g.createdAt DESC
+          """)
+       List<Group> findAccessibleGroupsByCategory(@Param("groupType") GroupType groupType, @Param("userId") Long userId);
 
     @Query("""
             SELECT DISTINCT g

--- a/backend/src/main/java/com/my_app/schoolboard/service/GroupService.java
+++ b/backend/src/main/java/com/my_app/schoolboard/service/GroupService.java
@@ -13,6 +13,8 @@ public interface GroupService {
 
     List<GroupResponseDTO> getGroups(String username);
 
+    List<GroupResponseDTO> filterGroupsByCategory(String category, String username);
+
     List<GroupResponseDTO> getMyGroups(String username);
 
     void joinGroup(Long groupId, String username);

--- a/backend/src/main/java/com/my_app/schoolboard/service/impl/GroupServiceImpl.java
+++ b/backend/src/main/java/com/my_app/schoolboard/service/impl/GroupServiceImpl.java
@@ -1,6 +1,7 @@
 package com.my_app.schoolboard.service.impl;
 
 import java.util.List;
+import java.util.Locale;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,6 +13,7 @@ import com.my_app.schoolboard.exception.ResourceNotFoundException;
 import com.my_app.schoolboard.model.Group;
 import com.my_app.schoolboard.model.GroupMember;
 import com.my_app.schoolboard.model.GroupMemberRole;
+import com.my_app.schoolboard.model.GroupType;
 import com.my_app.schoolboard.model.GroupVisibility;
 import com.my_app.schoolboard.model.Role;
 import com.my_app.schoolboard.model.User;
@@ -83,6 +85,30 @@ public class GroupServiceImpl implements GroupService {
     public List<GroupResponseDTO> getGroups(String username) {
         User currentUser = getUserByUsername(username);
         return groupRepository.findAccessibleGroups(currentUser.getId()).stream()
+                .map(group -> {
+                    GroupMember membership = getMembership(group.getId(), currentUser.getId()).orElse(null);
+                    return mapToGroupResponse(group, currentUser.getId(),
+                            membership != null ? membership.getRole() : null,
+                            membership != null);
+                })
+                .toList();
+    }
+
+    @Override
+    public List<GroupResponseDTO> filterGroupsByCategory(String category, String username) {
+        if (category == null || category.trim().isEmpty()) {
+            return getGroups(username);
+        }
+
+        GroupType groupType;
+        try {
+            groupType = GroupType.valueOf(category.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ex) {
+            return List.of();
+        }
+
+        User currentUser = getUserByUsername(username);
+        return groupRepository.findAccessibleGroupsByCategory(groupType, currentUser.getId()).stream()
                 .map(group -> {
                     GroupMember membership = getMembership(group.getId(), currentUser.getId()).orElse(null);
                     return mapToGroupResponse(group, currentUser.getId(),

--- a/frontend/src/pages/MyGroups.jsx
+++ b/frontend/src/pages/MyGroups.jsx
@@ -4,10 +4,21 @@ import { FolderPlus, Users } from 'lucide-react';
 import groupService from '../services/groupService';
 import GroupCard from '../components/GroupCard';
 
+const GROUP_CATEGORY_OPTIONS = [
+  { value: 'COURSE', label: 'Course' },
+  { value: 'BATCH', label: 'Batch' },
+  { value: 'STUDY_GROUP', label: 'Study Group' },
+  { value: 'PROJECT', label: 'Project' },
+  { value: 'EXAM_PREP', label: 'Exam Prep' },
+  { value: 'CLUB', label: 'Club' },
+  { value: 'MENTORSHIP', label: 'Mentorship' },
+];
+
 const MyGroups = () => {
   const navigate = useNavigate();
   const [myGroups, setMyGroups] = useState([]);
   const [discoverGroups, setDiscoverGroups] = useState([]);
+  const [selectedCategory, setSelectedCategory] = useState('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
 
@@ -17,10 +28,14 @@ const MyGroups = () => {
       setError('');
 
       try {
-        const [myGroupsData, allGroupsData] = await Promise.all([
-          groupService.getMyGroups(),
-          groupService.getGroups(),
-        ]);
+        if (selectedCategory) {
+          const allGroupsData = await groupService.getGroupsByCategory(selectedCategory);
+          setMyGroups(allGroupsData.filter((group) => group.joined));
+          setDiscoverGroups(allGroupsData.filter((group) => !group.joined));
+          return;
+        }
+
+        const [myGroupsData, allGroupsData] = await Promise.all([groupService.getMyGroups(), groupService.getGroups()]);
 
         setMyGroups(myGroupsData);
         setDiscoverGroups(allGroupsData.filter((group) => !group.joined));
@@ -32,7 +47,7 @@ const MyGroups = () => {
     };
 
     loadGroups();
-  }, []);
+  }, [selectedCategory]);
 
   return (
     <div className="space-y-6">
@@ -45,14 +60,43 @@ const MyGroups = () => {
               See the groups you already belong to and discover more spaces for collaboration, projects, and revision.
             </p>
           </div>
-          <button
-            type="button"
-            onClick={() => navigate('/groups/create')}
-            className="inline-flex items-center justify-center gap-2 rounded-2xl bg-blue-600 px-5 py-3 text-sm font-semibold text-white transition hover:bg-blue-700"
-          >
-            <FolderPlus className="h-4 w-4" />
-            Create Group
-          </button>
+          <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:items-center">
+            <div className="flex items-center gap-2">
+              <label htmlFor="groupCategory" className="text-sm font-medium text-gray-700">
+                Category
+              </label>
+              <select
+                id="groupCategory"
+                value={selectedCategory}
+                onChange={(event) => setSelectedCategory(event.target.value)}
+                className="rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
+              >
+                <option value="">All</option>
+                {GROUP_CATEGORY_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              {selectedCategory && (
+                <button
+                  type="button"
+                  onClick={() => setSelectedCategory('')}
+                  className="rounded-xl border border-gray-200 px-3 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50"
+                >
+                  Clear
+                </button>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={() => navigate('/groups/create')}
+              className="inline-flex items-center justify-center gap-2 rounded-2xl bg-blue-600 px-5 py-3 text-sm font-semibold text-white transition hover:bg-blue-700"
+            >
+              <FolderPlus className="h-4 w-4" />
+              Create Group
+            </button>
+          </div>
         </div>
       </div>
 

--- a/frontend/src/services/groupService.js
+++ b/frontend/src/services/groupService.js
@@ -21,6 +21,16 @@ const groupService = {
     }
   },
 
+  getGroupsByCategory: async (category) => {
+    try {
+      const response = await apiClient.get(`/groups?category=${encodeURIComponent(category)}`);
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching groups by category:', error);
+      throw error.response?.data || new Error('Network error fetching groups by category');
+    }
+  },
+
   getMyGroups: async () => {
     try {
       const response = await apiClient.get('/groups/my-groups');


### PR DESCRIPTION
This PR introduces category-based filtering for groups, allowing users to browse groups within specific academic fields.

Users can now select a category from a dropdown to view only groups that match the selected category.

✨ Changes
Backend
Added query to filter groups by category
Updated API to accept optional category parameter
Implemented service logic with access control:
public groups
or groups the user is a member of
Frontend
Added category filter dropdown to groups page
Connected filter to backend API
Dynamically updated group list based on selected category
Added option to clear filter and view all groups
✅ Acceptance Criteria
 Category filter is visible on groups page
 Users can select category to filter groups
 Only matching groups are displayed
 Users can clear filter to see all groups
 Feature works without errors
🧪 Testing

Manually verified:

 Selecting a category filters groups correctly
 Clearing filter restores full list
 No console or UI errors
 Only accessible groups are shown
 UI updates without page reload
📌 Notes
Reused existing group list and UI components
No changes made to overall UI structure
Maintained consistency with existing API patterns